### PR TITLE
Remove empty module XCSP

### DIFF
--- a/src/ConstraintProgrammingExtensions.jl
+++ b/src/ConstraintProgrammingExtensions.jl
@@ -26,6 +26,5 @@ include("Bridges/Bridges.jl")
 include("Test/Test.jl")
 
 include("FlatZinc/FlatZinc.jl")
-include("XCSP/XCSP.jl")
 
 end

--- a/src/XCSP/XCSP.jl
+++ b/src/XCSP/XCSP.jl
@@ -1,3 +1,0 @@
-module XCSP
-
-end


### PR DESCRIPTION
As the module is empty, it might as well be removed